### PR TITLE
feat: read ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS from the environment

### DIFF
--- a/craftr/settings.py
+++ b/craftr/settings.py
@@ -25,14 +25,24 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
+# Both lists come from the environment as comma-separated values, so the same
+# code runs on Railway and on the AWS box without an edit. The defaults are the
+# values that were previously hardcoded here, so leaving the variables unset
+# keeps the existing deployment behaving exactly as before.
 CSRF_TRUSTED_ORIGINS = [
-    "http://127.0.0.1:8000/",
-    "https://*.herokuapp.com",
-    "https://*.railway.app",
-    "https://*.vercel.app",
+    o.strip() for o in os.environ.get(
+        "CSRF_TRUSTED_ORIGINS",
+        "http://127.0.0.1:8000/,https://*.herokuapp.com,"
+        "https://*.railway.app,https://*.vercel.app",
+    ).split(",") if o.strip()
 ]
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.railway.app', '.vercel.app']
+ALLOWED_HOSTS = [
+    h.strip() for h in os.environ.get(
+        "ALLOWED_HOSTS",
+        "localhost,127.0.0.1,.railway.app,.vercel.app",
+    ).split(",") if h.strip()
+]
 
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Both `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` were hardcoded to the Railway and Vercel domains, so serving the app from any other address meant editing `settings.py`. They now read from comma-separated environment variables.

**The defaults are exactly the values that were hardcoded before**, so with the variables unset nothing changes. Verified:

```
unset -> matches old ALLOWED_HOSTS:  True
unset -> matches old CSRF_TRUSTED:   True
```

Whitespace and empty entries are stripped, so a pasted `"a, b, c"` works.

**Why this matters for the AWS migration:** the same commit can run on Railway and on the new box, so cutover is reversible - if the new host misbehaves, DNS points back to Railway with no code change and no redeploy.

Note: craftr already had an `ALLOWED_HOSTS` variable set in its Railway environment that the code never read. This makes it actually take effect.