### PR TITLE
chore: log unhandled exceptions to stderr

### DIFF
--- a/craftr/settings.py
+++ b/craftr/settings.py
@@ -172,3 +172,30 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Django sends 500 tracebacks to ADMINS by email and prints nothing when
+# DEBUG is False. With no ADMINS set, unhandled exceptions vanish entirely.
+# Writing to stderr puts them wherever the process log goes - the console in
+# development, the systemd journal in production. The app's own loggers are
+# covered by root, since its apps are top-level modules rather than sharing a
+# package namespace.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'WARNING',
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+    },
+}


### PR DESCRIPTION
Django sends 500 tracebacks to `ADMINS` by email and prints nothing when `DEBUG=False`. With no `ADMINS` configured, unhandled exceptions vanish entirely.

This came up on the-cult-film-club, where a 500 on a real Stripe webhook delivery could not be diagnosed at all because nothing was written anywhere. craftr has the same gap, and now runs on the same box - where the systemd journal is the only window into what the app is doing.

Sends `django` errors and anything at WARNING or above to stderr, which reaches the journal in production and the console in development.

Deliberately matches the `LOGGING` config `tardis-archives` already uses, rather than introducing a third shape. Root covers the app's own loggers because craftr's apps (`home`, `diary`, `details`, `faq`, `contact`, `login`, `register`, `account`) are top-level modules and share no package namespace.

No behaviour change beyond logging.