### PR TITLE
fix: send email through Amazon SES instead of Fastmail

### DIFF
--- a/craftr/settings.py
+++ b/craftr/settings.py
@@ -10,16 +10,28 @@ SITE_ID = 1
 
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 
+# Email goes through Amazon SES, which has dominicfrancis.co.uk verified with
+# DKIM, so any address on the domain can send.
+#
+# DEFAULT_FROM_EMAIL was never set, so Django fell back to webmaster@localhost
+# and every message was refused by the mail server. Nothing the app sends -
+# the contact form, password resets - has ever been delivered.
+#
+# No credentials are configured: django-ses uses boto3, which picks up the
+# EC2 instance role. The role may only send as the address below.
+DEFAULT_FROM_EMAIL = 'craftr@dominicfrancis.co.uk'
+
 if DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 if not DEBUG:
-    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_HOST = 'smtp.fastmail.com'
-    EMAIL_PORT = 587
-    EMAIL_USE_TLS = True
-    EMAIL_HOST_USER = os.getenv('EMAIL_USER')
-    EMAIL_HOST_PASSWORD = os.getenv('EMAIL_PASSWORD')
+    EMAIL_BACKEND = 'django_ses.SESBackend'
+    AWS_SES_REGION_NAME = 'eu-west-2'
+    AWS_SES_REGION_ENDPOINT = 'email.eu-west-2.amazonaws.com'
+    # django-ses throttles itself by calling ses:GetSendQuota before every
+    # send. That action cannot be scoped to a resource, so allowing it would
+    # mean granting it account-wide. SES enforces its own rate limit anyway.
+    AWS_SES_AUTO_THROTTLE = None
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ django-countries==7.6.1
 django-crispy-forms==2.4
 django-js-asset==3.1.2
 django-model-utils==5.0.0
+django-ses==4.7.2
 django-star-ratings==0.9.2
 django-storages==1.14.6
 gunicorn==23.0.0


### PR DESCRIPTION
`DEFAULT_FROM_EMAIL` was never set, so Django fell back to its default of `webmaster@localhost`. No mail server accepts that as a `From` address, so **nothing this app sends has ever been delivered** - not the contact form, not password resets.

The sibling project hit the same wall from the other direction: it had a sensible from-address, but one the Fastmail account was not authorised to send as, producing `551 5.7.1 Not authorised to send from this header address` on every message. Both were invisible because neither app logged anything.

## Why SES

`dominicfrancis.co.uk` is already verified with DKIM in SES eu-west-2 and out of the sandbox (50,000/day), set up when the static sites' contact forms were migrated.

`django-ses` authenticates through boto3, which picks up the EC2 instance role, so **no mail credentials are stored anywhere** - nothing in Parameter Store, nothing on disk, nothing to rotate. The role policy restricts sending to `craftr@dominicfrancis.co.uk` via an `ses:FromAddress` condition.

`AWS_SES_AUTO_THROTTLE = None` because django-ses otherwise calls `ses:GetSendQuota` before every send, and that action cannot be scoped to a resource - granting it would mean account-wide. SES enforces its own rate limit regardless.

## Verified on the server

```
EMAIL_BACKEND     : django_ses.SESBackend
DEFAULT_FROM_EMAIL: craftr@dominicfrancis.co.uk
messages accepted by SES: 1
```

Site healthy after deploy (HTTP 200).