### PR TITLE
fix: send contact form email from an address SES can send as

### DIFF
--- a/contact/views.py
+++ b/contact/views.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render, redirect
 from django.core.mail import EmailMessage
+from django.conf import settings
 from .forms import ContactForm
 from django.contrib import messages
-import os
 import logging
 logger = logging.getLogger(__name__)
 
@@ -23,9 +23,12 @@ def contact_page(request):
                 f"Email: {form.cleaned_data.get('email', '')}\n"
                 f"Message: {form.cleaned_data.get('message', '')}"
             )
-            # Use safe from_email fallback
-            from_email = os.getenv("EMAIL_USER") or "no-reply@example.com"
-            to_email = [os.getenv("EMAIL_USER") or "no-reply@example.com"]
+            # The sender has to be an address SES is allowed to send as, which
+            # EMAIL_USER (a Fastmail login) is not - every message was refused.
+            # Enquiries come from and go to the site's own address; replies go
+            # to whoever filled the form in.
+            from_email = settings.DEFAULT_FROM_EMAIL
+            to_email = [settings.DEFAULT_FROM_EMAIL]
             reply_to_email = [form.cleaned_data.get("email", from_email)]
 
             email = EmailMessage(
@@ -36,13 +39,15 @@ def contact_page(request):
                 reply_to=reply_to_email
             )
 
-            # Try sending the email safely
+            # The submission is saved above, so the enquiry is safe whether or
+            # not this email gets out - the email only notifies us sooner. The
+            # visitor is told it was received either way, because it was;
+            # showing them an error would only prompt a duplicate submission.
+            # Previously a failure showed the error AND the success message.
             try:
                 email.send()
-                print("Email sent successfully (or printed to console in dev)")
             except Exception as e:
-                logger.error(f"Contact form email failed: {e}")
-                messages.error(request, "We couldn't send your message at this time. Please try again later.")
+                logger.exception("Contact form notification failed: %s", e)
 
             messages.success(request, "Your message has been sent")
             return redirect('home')


### PR DESCRIPTION
The contact view built its sender from an environment variable:

```python
from_email = os.getenv("EMAIL_USER") or "no-reply@example.com"
```

`EMAIL_USER` is a Fastmail login address, which SES is not authorised to send as - so every contact form email was refused. It now uses `DEFAULT_FROM_EMAIL`, the site's own address and the one the EC2 instance role is permitted to send from. `Reply-To` still points at whoever filled the form in.

## Also fixes a misleading message

`messages.success(request, "Your message has been sent")` ran unconditionally, outside the `try/except`. On a send failure the visitor saw the error **and** the success message together.

The submission is saved to the database before the email, so the enquiry is safe whether or not the email gets out - the email only surfaces it sooner. The visitor is now told it was received either way, because it was; showing an error would only prompt a duplicate submission. The failure is logged instead.

Drops the now-unused `os` import.

**Merge after #93**, which adds the SES backend and sets `DEFAULT_FROM_EMAIL`.

## Verified on the server

Real form submission through `https://craftr.dominicfrancis.co.uk/contact/` returned 302, and the notification email was received.