### PR TITLE
ci: deploy to AWS automatically on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       # token for temporary credentials; the role only trusts this repo's main
       # branch and can only invoke the DeployApp document on the one instance.
       - name: Get temporary AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::115019371912:role/github-actions-deploy
           aws-region: eu-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy
+
+# Replaces the automatic deploys Railway used to do. On a push to main this
+# asks the apps box to run its own deploy script, which pulls this commit,
+# installs, migrates (snapshotting the database first if the schema changes),
+# restarts and smoke-tests - rolling back if the smoke test fails.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:      # so a deploy can also be triggered by hand
+
+# One deploy at a time. Without this, two quick merges could have the box
+# pulling a new commit while the previous run is still installing.
+concurrency:
+  group: deploy-craftr
+  cancel-in-progress: false
+
+permissions:
+  id-token: write         # required to request the OIDC token
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # No AWS keys are stored in GitHub. This exchanges a short-lived OIDC
+      # token for temporary credentials; the role only trusts this repo's main
+      # branch and can only invoke the DeployApp document on the one instance.
+      - name: Get temporary AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::115019371912:role/github-actions-deploy
+          aws-region: eu-west-2
+
+      - name: Deploy
+        run: |
+          set -euo pipefail
+          command_id=$(aws ssm send-command \
+            --document-name DeployApp \
+            --instance-ids i-07bca300c5bb852d9 \
+            --parameters app=craftr \
+            --comment "GitHub Actions: ${GITHUB_SHA::7} by ${GITHUB_ACTOR}" \
+            --query Command.CommandId --output text)
+          echo "SSM command: $command_id"
+
+          # Poll rather than using `aws ssm wait`, so the deploy script's own
+          # output ends up in the workflow log whether it passes or fails.
+          for _ in $(seq 1 60); do
+            status=$(aws ssm get-command-invocation \
+              --command-id "$command_id" \
+              --instance-id i-07bca300c5bb852d9 \
+              --query Status --output text 2>/dev/null || echo Pending)
+            case "$status" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+            sleep 10
+          done
+
+          echo "--- deploy output ---"
+          aws ssm get-command-invocation \
+            --command-id "$command_id" \
+            --instance-id i-07bca300c5bb852d9 \
+            --query StandardOutputContent --output text
+
+          errors=$(aws ssm get-command-invocation \
+            --command-id "$command_id" \
+            --instance-id i-07bca300c5bb852d9 \
+            --query StandardErrorContent --output text)
+          [ -n "$errors" ] && { echo "--- stderr ---"; echo "$errors"; }
+
+          echo "--- status: $status ---"
+          [ "$status" = "Success" ]


### PR DESCRIPTION
Adds the same deploy workflow already proven on `tardis-archives` (dvfrancis/tardis-archives#6), restoring the push-to-deploy behaviour Railway provided.

On a push to `main`, GitHub asks the apps box to run its own deploy script: pull the commit, install, `collectstatic`, **take an RDS snapshot if and only if migrations are pending**, migrate, restart, smoke-test - rolling the code back automatically if the smoke test fails.

## No AWS credentials in GitHub

The workflow exchanges a short-lived OIDC token for temporary credentials. The IAM role only trusts this repository's `main` branch, so a fork PR or another branch cannot assume it.

## The role cannot run arbitrary commands on the server

Rather than granting `ssm:SendCommand` on `AWS-RunShellScript` - which would allow any shell command as root - the role may only invoke a dedicated `DeployApp` SSM document whose single step is `/usr/local/bin/deploy-app {{ app }}`, with `app` constrained by `allowedValues`. The worst a stolen token can do is redeploy code already on `main`.

Proven on the first run for tardis-archives.