### PR TITLE
Deploy through this repo's own role and document

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,20 +25,30 @@ jobs:
     steps:
       # No AWS keys are stored in GitHub. This exchanges a short-lived OIDC
       # token for temporary credentials; the role only trusts this repo's main
-      # branch and can only invoke the DeployApp document on the one instance.
+      # branch and can only invoke the DeployCraftr document on the one instance.
+      #
+      # That trust is pinned to the repository NAME as well as its immutable ID.
+      # The role's trust policy matches the token's subject claim as an exact
+      # string, so renaming or moving this repository can break deploys - which
+      # is not obvious from the failure, because the error ("Not authorized to
+      # perform sts:AssumeRoleWithWebIdentity") names neither the repository nor
+      # the condition that did not match. This has happened once already, to
+      # kanban. The ID form below survives a rename; keep both.
+      #
+      # The role is defined in apps-box-config/infra/github-actions-deploy-role.yaml.
+      # Change it there and apply the stack - not by hand in the console.
       - name: Get temporary AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::115019371912:role/github-actions-deploy
+          role-to-assume: arn:aws:iam::115019371912:role/github-actions-deploy-craftr
           aws-region: eu-west-2
 
       - name: Deploy
         run: |
           set -euo pipefail
           command_id=$(aws ssm send-command \
-            --document-name DeployApp \
+            --document-name DeployCraftr \
             --instance-ids i-07bca300c5bb852d9 \
-            --parameters app=craftr \
             --comment "GitHub Actions: ${GITHUB_SHA::7} by ${GITHUB_ACTOR}" \
             --query Command.CommandId --output text)
           echo "SSM command: $command_id"


### PR DESCRIPTION
The shared `github-actions-deploy` role could invoke `DeployApp`, whose `app` parameter accepted `craftr`, `cultfilmclub`, `tardis` **and `kanban`**. A role is scoped to a *document*, not to a parameter value — so any of those repositories could deploy any of the others, including kanban, whose repository belongs to someone else.

This switches to `github-actions-deploy-craftr` and `DeployCraftr`, which has the app name hardcoded. The `--parameters app=craftr` flag goes with it.

Both the role and the document already exist — added in [apps-box-config#3](https://github.com/dvfrancis/apps-box-config/pull/3) and applied, so this PR is the switch-over, not the creation.

## Verified before opening this

`simulate-principal-policy` against the new role:

| Document | Decision |
|---|---|
| `DeployCraftr` | **allowed** |
| the other three app documents | implicitDeny |
| `DeployApp` | implicitDeny |

## Merging this triggers a real deploy

That is the point — it is the only honest proof the new role works. It redeploys the current commit of craftr.dominicfrancis.co.uk, so a no-op in effect, but it does restart the service. If it fails, reverting this one PR restores the old path; the shared role and `DeployApp` are deliberately still in place until all three sites have had a green deploy.

## Also here

The header comment now records that trust is pinned to the repository name as well as its immutable ID. That coupling is invisible from this file and is exactly what broke kanban's deploys this morning after it was renamed — with an error naming neither the repository nor the condition that failed.