### PR TITLE
fix: drop the diary view's unused, broken class queryset

### DIFF
--- a/diary/views.py
+++ b/diary/views.py
@@ -1,27 +1,20 @@
 from django.shortcuts import render
 from diary.models import EventDay
-from details.models import EventClass
 
 
 def diary_details(request):
     """
     Render the diary details page.
 
-    This view fetches and displays a list of event days and their associated
-    event classes, sorted by date and time.
+    This view fetches and displays the list of event days. Each day's classes
+    are reached in the template through the event_day reverse accessor, so
+    they are not queried separately here.
 
     Args:
         request: The HTTP request object.
 
     Returns:
-        HttpResponse: The rendered diary details page with event days and
-        classes.
+        HttpResponse: The rendered diary details page with event days.
     """
     days = EventDay.objects.order_by("day_date")
-    classes = EventClass.objects.select_related("event_day") \
-        .order_by("event_day__class_date", "start_time")
-    return render(
-        request,
-        "diary/diary.html",
-        {"days": days, "classes": classes}
-    )
+    return render(request, "diary/diary.html", {"days": days})


### PR DESCRIPTION
`diary/views.py` built a second queryset ordered on `event_day__class_date`, a field renamed to `day_date` by migration `diary/0005`. Evaluating it raises `FieldError`.

It never has fired, because `diary/diary.html` reaches each day's classes through the `event_day` reverse accessor (`day.event_day.all|dictsort:"start_time"`) and never reads the `classes` context entry. Confirmed by grep: no template uses it as a variable.

Removed the queryset and the now-unused `EventClass` import rather than correcting the field name, which takes the landmine out entirely. Querysets are lazy, so this changes no queries at runtime.

Verified: `py_compile` clean, all lines under 79 characters.