### PR TITLE
chore: port the storage settings to the STORAGES dict

### DIFF
--- a/craftr/settings.py
+++ b/craftr/settings.py
@@ -93,7 +93,8 @@ CLOUDINARY_STORAGE = {
     'API_SECRET': os.getenv('CLOUDINARY_API_SECRET'),
 }
 
-DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
+# Media storage is configured in the STORAGES dict, down with the static
+# settings, because Django 5.1 collapsed both into that one dict.
 
 MEDIA_URL = '/assets/'
 MEDIA_ROOT = os.path.join(BASE_DIR, "assets")
@@ -179,9 +180,29 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
+# BASE_DIR/'static' has never existed. The only static sources in the repo
+# sit under the project package, which is not in INSTALLED_APPS and so is
+# never reached by AppDirectoriesFinder either.
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'craftr', 'static')]
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+# Django 5.1 replaced DEFAULT_FILE_STORAGE and STATICFILES_STORAGE with this
+# dict. The old names were ignored in silence, which is why STATIC_ROOT holds
+# no compressed assets and no staticfiles.json manifest.
+#
+# staticfiles deliberately uses the non-manifest backend. Manifest storage
+# resolves every {% static %} tag through staticfiles.json and raises
+# ValueError when the entry is missing, so a deploy that does not run
+# collectstatic takes the whole site down rather than one page. Nothing in
+# this repo shows whether the box's deploy script runs it. Confirm that
+# before switching to CompressedManifestStaticFilesStorage.
+STORAGES = {
+    'default': {
+        'BACKEND': 'cloudinary_storage.storage.MediaCloudinaryStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'whitenoise.storage.CompressedStaticFilesStorage',
+    },
+}
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 


### PR DESCRIPTION
Django 5.1 removed `DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE`; `requirements.txt` pins Django 5.2.1. Both were being ignored in silence, so WhiteNoise compression was never active and Cloudinary was never the default file storage. Media still reached Cloudinary only because `CloudinaryField` builds its own URLs independently of the storage backend.

## Changes

- `STORAGES` dict replaces both dead settings.
- `STATICFILES_DIRS` now points at `craftr/static`, the only static source in the repo. It pointed at `BASE_DIR/'static'`, which has never existed.

## Why the non-manifest backend

`CompressedManifestStaticFilesStorage` resolves every `{% static %}` tag through `staticfiles.json` and raises `ValueError` on a miss. A deploy that skips `collectstatic` therefore takes the **whole site** down, not one page. `STATIC_ROOT` currently has no manifest and zero `.gz`/`.br` files, which suggests `collectstatic` does not run during deploy. Since the deploy script lives on the EC2 box and not in this repo, that cannot be confirmed from here.

`CompressedStaticFilesStorage` has no such failure mode: it compresses during `collectstatic` and is otherwise inert.

## Verification

Ran against a clean Django 5.2.1 environment:

| Check | Before | After |
|---|---|---|
| `manage.py check` | `staticfiles.W004` (1 issue) | 0 issues |
| `storages['default']` | ignored | `cloudinary_storage.storage.MediaCloudinaryStorage` |
| `storages['staticfiles']` | ignored | `whitenoise.storage.CompressedStaticFilesStorage` |

`collectstatic --dry-run` reports the three `craftr/static` files as **unmodified**, so it overwrites nothing. The other 137 are Django admin and cloudinary package assets already present at the same pinned versions.

## Not addressed here

12 files in `STATIC_ROOT` have no discoverable source (per-app `styles.css`, three images). No template references any of them, so they are dead weight rather than a hazard. Left alone deliberately.