### PR TITLE
docs: correct the local deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,26 +1045,37 @@ Copy the GitHub repository locally in one of two ways:
 2. Clone the repository using the `git clone` command followed by the repository clone link; for example:
     - `git clone https://github.com/dvfrancis/craftr.git`
 
-- Once this has been done, open a terminal window and install all requirements using the command:
+- Open a terminal window in the root of the project folder. Stay there for everything that follows, because `settings.py` looks for your environment file in the current working directory rather than alongside itself.
+- Create and activate a virtual environment, so the project's packages are kept out of your system Python:
+
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    ```
+
+    On Windows the activation command is `.venv\Scripts\activate` instead.
+
+- Install all requirements using the command:
     - `pip3 install -r requirements.txt`
-- In the root of the project folder, create a `.gitignore` file, and add `env.py` and `__pycache__` to protect sensitive data.
-- Add the following information to `env.py`:
-    
-   ```python
-    import os
+- Create a file named `.env` in the root of the project folder. There is no need to create a `.gitignore`; the repository ships with one that already covers `.env`, `.venv` and `__pycache__`. Add the following:
 
-      os.environ['SECRET_KEY'] = 'Add your database secret key'
-      os.environ['DATABASE_URL'] = 'Add your database URL'
-      os.environ['DEBUG'] = 'Set this to True'
-    ```
-*While developing leave `DEBUG=True`, but remember to change it to `DEBUG=False` when you deploy your final project*
-- Run the following commands to push everything to the database:
-    
-    ```Python
-        python3 manage.py makemigrations
-        python3 manage.py migrate
+    ```text
+    SECRET_KEY='Add your Django secret key'
+    DATABASE_URL='Add your database URL'
+    DEBUG='True'
+    CLOUDINARY_CLOUD_NAME='Add your Cloudinary cloud name'
+    CLOUDINARY_API_KEY='Add your Cloudinary API key'
+    CLOUDINARY_API_SECRET='Add your Cloudinary API secret'
     ```
 
+*`SECRET_KEY` and `DATABASE_URL` have no fallback, so `manage.py` will not start without them. The three Cloudinary values fall back to `None`, which lets the site run but leaves every uploaded image broken.*
+
+*`DEBUG` is compared against the exact string `True`, so `true` and `1` both count as false. Leave it as `True` while developing. In production the variable is left unset, which also switches the email backend from the console to Amazon SES.*
+
+*The database is configured with `ssl_require=True`. The Code Institute database described above supports TLS, but a plain local PostgreSQL install will refuse the connection with `server does not support SSL, but SSL was required` until you enable SSL on it.*
+
+- Apply the migrations. Every migration file is committed, so `makemigrations` is not needed on a fresh clone:
+    - `python3 manage.py migrate`
 - Now create the superuser account (completing the necessary information when prompted):
     - `python3 manage.py createsuperuser`
 - Run the webserver:


### PR DESCRIPTION
The Local deployment section told you to create an `env.py` and set `os.environ` inside it. **Nothing in the codebase reads `env.py`.** `settings.py` calls `load_dotenv()` and reads a `.env` file, so anyone following these steps ended up with a site that would not start.

## Corrections

| Was | Now |
|---|---|
| Create `env.py` with `os.environ[...]` assignments | Create `.env` with plain `KEY='value'` lines |
| "Create a `.gitignore` file, and add `env.py` and `__pycache__`" | Removed. The repo ships a `.gitignore` already covering `.env`, `.venv` and `__pycache__` |
| Three variables listed | Six. The Cloudinary trio was missing, and without it every uploaded image is broken |
| `makemigrations` then `migrate` | `migrate` alone |
| No virtual environment | `python3 -m venv .venv` step added, so requirements do not install into system Python |

## Gotchas now documented

- **`DEBUG` is compared against the exact string `True`.** `true` and `1` both read as false.
- **The `.env` file is located relative to the working directory,** not to `settings.py`. `load_dotenv()` only fires behind `if os.path.isfile(".env")`, so running `manage.py` from anywhere but the repo root silently skips your whole environment.
- **`ssl_require=True` breaks a plain local PostgreSQL.** The real error is quoted in the README.

## Verification

- `grep` across all `*.py`: zero references to `env.py`. It is dead documentation, not a mechanism.
- `manage.py makemigrations --check --dry-run` reports `No changes detected`, confirming `migrate` alone is sufficient.
- The SSL failure was reproduced against a local PostgreSQL: `server does not support SSL, but SSL was required`.
- `.venv` confirmed present in `.gitignore` (line 135) before recommending that path.

## Deliberately not touched

The **Heroku Deployment** section below is also obsolete: the project deploys to AWS via GitHub Actions, `EMAIL_USER` and `EMAIL_PASSWORD` no longer exist in `settings.py` (SES authenticates through the EC2 instance role), and it references `env.py` again at line 1108. Whether that section should be deleted or rewritten as AWS deployment docs is a judgement call about the Code Institute submission, so it is left alone here.

`TESTING.md` also mentions `env.py` twice, but both are historical fixed-bug entries describing what was true at the time. Correct as a record; left alone.