### PR TITLE
docs: correct alt text carried over from another project

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This website serves as the central hub for the Craftr event, providing informati
 
 ### Site Preview
 
-![A preview of the Hi-Lo website at various screen sizes](assets/images/site-preview.webp)
+![A preview of the Craftr website at various screen sizes](assets/images/site-preview.webp)
 
 ### Site Link
 
@@ -601,7 +601,7 @@ The wireframe designs shown below were my initial ideas for each page of the web
 <details>
 <summary>Click to view the mobile device classes wireframe</summary>
 
-![Mobile game page wireframe](documentation/wireframes/mobile/mobile-diary.webp)
+![Mobile classes page wireframe](documentation/wireframes/mobile/mobile-diary.webp)
 </details>
 
 ##### Class Details
@@ -691,7 +691,7 @@ The wireframe designs shown below were my initial ideas for each page of the web
 <details>
 <summary>Click to view the tablet device classes wireframe</summary>
 
-![Tablet game page wireframe](documentation/wireframes/tablet/tablet-diary.webp)
+![Tablet classes page wireframe](documentation/wireframes/tablet/tablet-diary.webp)
 </details>
 
 ##### Class Details
@@ -781,7 +781,7 @@ The wireframe designs shown below were my initial ideas for each page of the web
 <details>
 <summary>Click to view the desktop device classes wireframe</summary>
 
-![Desktop game page wireframe](documentation/wireframes/desktop/desktop-diary.webp)
+![Desktop classes page wireframe](documentation/wireframes/desktop/desktop-diary.webp)
 </details>
 
 ##### Class Details


### PR DESCRIPTION
Four images in the README described a different site.

| Line | Was | Now |
|---|---|---|
| 27 | `A preview of the **Hi-Lo** website at various screen sizes` | `...the **Craftr** website...` |
| 604 | `Mobile **game** page wireframe` | `Mobile **classes** page wireframe` |
| 694 | `Tablet **game** page wireframe` | `Tablet **classes** page wireframe` |
| 784 | `Desktop **game** page wireframe` | `Desktop **classes** page wireframe` |

Craftr has no game page. Hi-Lo, a guessing game, presumably did.

## Why "classes"

Three independent signals agreed, so this is not a guess:

- The files are `mobile-diary.webp`, `tablet-diary.webp`, `desktop-diary.webp`.
- The `<summary>` element directly above each image already reads "Click to view the *device* device **classes** wireframe".
- The nav labels that page `CLASSES`, and the README elsewhere uses "Website classes page".

The alt text was the only part that disagreed with its own surroundings.

## Why it is worth a PR

Alt text is what a screen reader announces. These four images were describing the wrong website to the people who depend on that description most, while looking perfectly fine to everyone else.

## Swept while here

- No `Hi-Lo` or `game` references remain in `README.md` or `TESTING.md`.
- Every image path in the README resolves on disk: 0 missing.
- No empty alt attributes.

Text only. No images were changed, moved, or renamed.