### PR TITLE
fix: serve Cloudinary images over https

### DIFF
--- a/craftr/settings.py
+++ b/craftr/settings.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import cloudinary
 import dj_database_url
 from dotenv import load_dotenv
 
@@ -92,6 +93,21 @@ CLOUDINARY_STORAGE = {
     'API_KEY': os.getenv('CLOUDINARY_API_KEY'),
     'API_SECRET': os.getenv('CLOUDINARY_API_SECRET'),
 }
+
+# Force HTTPS on every generated image URL (issue #113). Without this, images
+# were served over http:// on an https:// page, which browsers treat as mixed
+# content.
+#
+# Setting SECURE in the dict above does nothing, which is the trap here.
+# django-cloudinary-storage already defaults it to True, but it applies that
+# default from cloudinary_storage.app_settings, and that module is only
+# imported when something touches the storage backend. CloudinaryField comes
+# from cloudinary.models and talks to Cloudinary directly, so STORAGES never
+# gets instantiated, the package never loads, and the global config stays at
+# secure=None - which the library reads as false.
+#
+# Configuring it here does not depend on another package's import order.
+cloudinary.config(secure=True)
 
 # Media storage is configured in the STORAGES dict, down with the static
 # settings, because Django 5.1 collapsed both into that one dict.


### PR DESCRIPTION
Closes #113.

Every uploaded image was served over `http://` on an `https://` page, two per class page across all 21 class pages. Browsers treat that as mixed content.

## The trap

Adding `SECURE: True` to `CLOUDINARY_STORAGE` would have changed nothing, which is why this is worth a note rather than a one-liner.

`cloudinary_storage/app_settings.py:40` already runs `cloudinary.config(secure=user_settings.get("SECURE", True))`. The default is `True`. But that line only executes when the module is imported, and nothing imports it: templates build URLs through `{{ event_class.class_image.url }}`, which is `CloudinaryResource.url` from `cloudinary.models`. `CloudinaryField` bypasses Djangos storage API entirely, so `STORAGES["default"]` is never instantiated, `cloudinary_storage` never loads, and the global config sits at `secure=None` - which the library reads as false.

Configuring it explicitly in `settings.py` removes the dependency on another packages import order.

## Verification

Reproduced and confirmed against Django 5.2.1 with cloudinary 1.44.0, using the real public ID of a live class image:

| State | URL scheme | `cloudinary.config().secure` |
|---|---|---|
| As shipped | `http://` | `None` |
| After importing `app_settings` by hand | `https://` | `True` |
| **After this change** | **`https://`** | **`True`** |

Also: `manage.py check` reports 0 issues, and every line stays under 79 characters.

## Scope

One setting and one import. No template, model, or migration changes.

This overlaps #112, which would fix the same defect as a side effect of moving to S3 and CloudFront. Kept separate because #112 is explicitly not urgent and this is live on every class page today. The `cloudinary.config` call goes away with the rest of Cloudinary in the final phase of #112.

Worth confirming on production after the deploy, since the local proof uses the same code path but not the same data:

```
curl -s https://craftr.dominicfrancis.co.uk/details/3/ | grep -c "http://res.cloudinary"
```

should return `0`.