### PR TITLE
infra: add the media bucket, certificate, CDN and permissions stacks

### DIFF
--- a/infra/media-bucket.yaml
+++ b/infra/media-bucket.yaml
@@ -1,0 +1,111 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Storage for Craftr class, instructor and profile images, replacing
+  Cloudinary. Creates the bucket only. Serving it through CloudFront is a
+  separate, later stack.
+
+# Part of issue #112. 42 uploaded images (21 classes, each with a class and an
+# instructor image, counted from the live site on 11 August 2026) plus an
+# unknown number of profile photographs, which sit behind login and could not
+# be counted from outside.
+#
+# Craftr is the last of the three sites on Cloudinary cloud name dvzs9gve0.
+# TARDIS Archives moved in tardis-archives#42 and The Cult Film Club has moved
+# since; once this migration finishes the Cloudinary account can be closed
+# rather than merely reduced.
+#
+# Per-app infrastructure lives in the repository it belongs to rather than in
+# apps-box-config, matching tardis-archives/infra/ and the-cult-film-club
+# /infra/. apps-box-config/infra/ holds only what is shared across the box.
+#
+# To apply:
+#
+#   aws cloudformation deploy \
+#     --stack-name craftr-media-bucket \
+#     --template-file infra/media-bucket.yaml \
+#     --region eu-west-2 \
+#     --profile admin
+#
+# No CAPABILITY_NAMED_IAM: this stack creates no roles or policies.
+
+# Deliberately NOT in this stack, in the order they will be needed:
+#
+#   1. A CloudFront distribution and Origin Access Control. The bucket blocks
+#      all public access, so nothing can read it from the internet yet. That
+#      is correct for now and blocking later: the images cannot be served
+#      until this exists.
+#   2. A bucket policy granting that distribution's OAC s3:GetObject. It has
+#      to name the distribution ARN, so it cannot be written before the
+#      distribution exists.
+#   3. s3:PutObject on this bucket for apps-ec2-role, so uploads through the
+#      admin and the profile form work. That belongs with the other
+#      instance-role grants and is a change to a role this stack does not own.
+#
+# Each of those is a real decision rather than an oversight, which is why the
+# bucket lands on its own first.
+
+Resources:
+  MediaBucket:
+    Type: AWS::S3::Bucket
+    # Retain on both, because the bucket will hold the only copy of every
+    # uploaded image. Deleting this stack should orphan the bucket, not empty
+    # it. A replacing update would be worse still: CloudFormation would create
+    # the replacement, then delete the original along with its contents.
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      # Fixed name rather than a generated one. The name appears in the Django
+      # settings on the box, in the CloudFront origin, and in the IAM policy
+      # ARNs, so a name that changed on replacement would break all three
+      # silently.
+      #
+      # Not "craftr", which would match tardis-archives and the-cult-film-club
+      # in using the bare application name. That name is already taken by
+      # another AWS account - bucket names are globally unique, and HeadBucket
+      # answers 403 rather than 404 for it. The suffixed form matches the
+      # account's other per-site buckets, hi-lo-card-game-dominicfrancis and
+      # older-and-wider-dominicfrancis.
+      BucketName: craftr-dominicfrancis
+
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            # Cuts the per-object encryption calls S3 makes on its own key.
+            # Free, and it matches every other bucket in the account.
+            BucketKeyEnabled: true
+
+      # The point of the migration. Cloudinary keeps one copy of each image and
+      # nothing else; versioning means an overwrite or a delete through the
+      # admin is recoverable. Old versions accumulate with no expiry, which is
+      # intended: this bucket will hold well under a gigabyte, so keeping every
+      # version indefinitely costs pennies a year and a lifecycle rule would
+      # only add a way to lose something.
+      VersioningConfiguration:
+        Status: Enabled
+
+      Tags:
+        - Key: Application
+          Value: craftr
+        - Key: ManagedBy
+          Value: cloudformation
+
+Outputs:
+  BucketName:
+    Description: Bucket name, for AWS_STORAGE_BUCKET_NAME in Django settings
+    Value: !Ref MediaBucket
+    Export:
+      Name: craftr-media-bucket-name
+
+  BucketRegionalDomainName:
+    Description: Origin domain for the CloudFront distribution added later
+    Value: !GetAtt MediaBucket.RegionalDomainName
+    Export:
+      Name: craftr-media-bucket-domain

--- a/infra/media-cdn.yaml
+++ b/infra/media-cdn.yaml
@@ -1,0 +1,159 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Serves the Craftr uploaded images from media.craftr.dominicfrancis.co.uk.
+  CloudFront distribution, the bucket policy that lets it read, and DNS.
+
+# Part of issue #112, and the step that makes infra/media-bucket.yaml usable.
+# The bucket blocks all public access, so until this stack exists nothing can
+# read an image from the internet.
+#
+# Deploy infra/media-certificate.yaml first, to us-east-1, and pass its output
+# here:
+#
+#   aws cloudformation deploy \
+#     --stack-name craftr-media-cdn \
+#     --template-file infra/media-cdn.yaml \
+#     --parameter-overrides CertificateArn=<arn from that stack> \
+#     --region eu-west-2 \
+#     --profile admin
+#
+# Expect 5 to 10 minutes: CloudFormation waits for the distribution to finish
+# deploying to every edge location.
+#
+# Still not here, and the last piece of #112's infrastructure: s3:PutObject on
+# the bucket for apps-ec2-role, so uploads through the Django admin and the
+# profile form work. That modifies a shared role this stack does not own, the
+# same reason the other two sites keep their grant in a stack of their own.
+
+Parameters:
+  CertificateArn:
+    Type: String
+    AllowedPattern: "^arn:aws:acm:us-east-1:[0-9]{12}:certificate/.+$"
+    ConstraintDescription: >-
+      Must be an ACM certificate ARN in us-east-1. CloudFront accepts
+      certificates from no other region.
+    Description: Output of the craftr-media-certificate stack in us-east-1.
+
+Resources:
+  # Origin Access Control replaces the old Origin Access Identity. The bucket
+  # stays private and CloudFront signs each origin request with SigV4; the
+  # bucket policy below is what trusts those signatures.
+  OriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: craftr-media-oac
+        Description: Signs CloudFront reads of the craftr-dominicfrancis bucket
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  Distribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: Craftr uploaded images
+        Aliases:
+          - media.craftr.dominicfrancis.co.uk
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        # Europe and North America only. Craftr is a UK event site, and the
+        # cheaper class simply omits the edge locations furthest from that
+        # audience rather than refusing to serve anyone.
+        PriceClass: PriceClass_100
+
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+
+        Origins:
+          - Id: MediaBucket
+            DomainName: !ImportValue craftr-media-bucket-domain
+            OriginAccessControlId: !GetAtt OriginAccessControl.Id
+            # Required by CloudFormation even for an S3 origin using OAC, and
+            # must be present and empty. A non-empty OriginAccessIdentity here
+            # would put the distribution back on the legacy mechanism.
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+
+        DefaultCacheBehavior:
+          TargetOriginId: MediaBucket
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods: [GET, HEAD]
+          CachedMethods: [GET, HEAD]
+          Compress: true
+          # Managed-CachingOptimized. Caches on the path alone, forwarding no
+          # cookies, headers or query strings, which is right here because an
+          # uploaded image is the same file for every visitor. The id is a
+          # fixed AWS-wide constant, not an account-specific value.
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+
+      Tags:
+        - Key: Application
+          Value: craftr
+        - Key: ManagedBy
+          Value: cloudformation
+
+  # Lives here rather than in media-bucket.yaml because it has to name the
+  # distribution, which that stack knows nothing about. CloudFormation is
+  # content for a bucket policy to sit in a different stack from its bucket.
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !ImportValue craftr-media-bucket-name
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowCloudFrontRead
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub
+              - "arn:aws:s3:::${Bucket}/*"
+              - Bucket: !ImportValue craftr-media-bucket-name
+            # Without this condition the grant would be to the CloudFront
+            # service rather than to this distribution, and any distribution
+            # in any AWS account could be pointed at the bucket and read it.
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub
+                  "arn:aws:cloudfront::${AWS::AccountId}:distribution/${Distribution}"
+
+  # Both records, because the distribution answers on IPv6 and a visitor on an
+  # IPv6-only network gets no address at all from the A record alone.
+  DnsIpv4:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: Z04281911KACWXVUQESMB
+      Name: media.craftr.dominicfrancis.co.uk
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt Distribution.DomainName
+        # Fixed constant meaning "a CloudFront distribution", identical in
+        # every account and region. It is not this account's hosted zone.
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+  DnsIpv6:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: Z04281911KACWXVUQESMB
+      Name: media.craftr.dominicfrancis.co.uk
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt Distribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+Outputs:
+  DistributionId:
+    Description: For cache invalidations after replacing an uploaded image
+    Value: !Ref Distribution
+
+  MediaUrl:
+    Description: Base URL for uploaded images, for the Django storage settings
+    Value: https://media.craftr.dominicfrancis.co.uk

--- a/infra/media-certificate.yaml
+++ b/infra/media-certificate.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  TLS certificate for media.craftr.dominicfrancis.co.uk, the domain the
+  uploaded images are served from. Must be deployed to us-east-1.
+
+# Part of issue #112, between infra/media-bucket.yaml and infra/media-cdn.yaml.
+#
+# This is a separate stack for one reason: CloudFront only accepts
+# certificates from us-east-1, no matter where the distribution serves from or
+# where its origin lives. Everything else in this migration is eu-west-2, so
+# splitting the certificate out is the smallest way to satisfy that without
+# moving the rest.
+#
+# CloudFormation exports cannot cross regions, so media-cdn.yaml takes the ARN
+# below as a parameter rather than importing it.
+#
+# To apply (note the region, it is not the usual one):
+#
+#   aws cloudformation deploy \
+#     --stack-name craftr-media-certificate \
+#     --template-file infra/media-certificate.yaml \
+#     --region us-east-1 \
+#     --profile admin
+#
+# The deploy blocks until the certificate is issued. Validation records are
+# written into the hosted zone automatically by the HostedZoneId below, so
+# this needs no manual DNS step, but it does usually sit for several minutes
+# looking as though it has stalled. It has not.
+
+Resources:
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      # A certificate for this exact name, rather than reusing a wildcard.
+      # A *.dominicfrancis.co.uk wildcard would not cover this anyway: wildcards
+      # match a single label, and this name is two levels below the zone apex.
+      DomainName: media.craftr.dominicfrancis.co.uk
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        # Naming the zone is what makes this automatic. Without it ACM still
+        # issues a CNAME to add, but waits for someone to add it by hand and
+        # the stack sits in CREATE_IN_PROGRESS until they do.
+        - DomainName: media.craftr.dominicfrancis.co.uk
+          HostedZoneId: Z04281911KACWXVUQESMB
+      Tags:
+        - Key: Application
+          Value: craftr
+        - Key: ManagedBy
+          Value: cloudformation
+
+Outputs:
+  CertificateArn:
+    Description: >-
+      Pass to media-cdn.yaml as its CertificateArn parameter. Not exported,
+      because exports are per-region and that stack is in eu-west-2.
+    Value: !Ref Certificate

--- a/infra/media-permissions.yaml
+++ b/infra/media-permissions.yaml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Lets the apps box read and write uploaded images in the
+  craftr-dominicfrancis bucket, so uploads through the Django admin and the
+  profile form work.
+
+# The last infrastructure piece of issue #112, after infra/media-bucket.yaml
+# and infra/media-cdn.yaml. Nothing else is needed in AWS after this; what
+# remains is application code and the copy itself.
+#
+# apps-ec2-role was created by hand and is not owned by any CloudFormation
+# stack. Rather than import that shared production role, this attaches one
+# more inline policy to it, exactly as write-tardis-covers and
+# write-cultfilmclub-media already do. It is the smallest footprint that keeps
+# the change in version control.
+#
+# To apply:
+#
+#   aws cloudformation deploy \
+#     --stack-name craftr-media-permissions \
+#     --template-file infra/media-permissions.yaml \
+#     --capabilities CAPABILITY_NAMED_IAM \
+#     --region eu-west-2 \
+#     --profile admin
+#
+# Keep that --capabilities flag even though `validate-template` reports this
+# template as needing none. It does not recognise AWS::IAM::RolePolicy, but
+# the deploy does: the applied tardis-media-permissions stack has
+# CAPABILITY_NAMED_IAM recorded against it.
+
+# No delete permission of any kind, matching the other two sites' reasoning.
+# Django does not need it: since 1.3 deleting a model row leaves its file
+# alone, and the admin's "clear" tickbox blanks the database column rather
+# than removing anything from storage. So nothing legitimate breaks, and a
+# compromised box cannot erase the images. Combined with versioning on the
+# bucket, even an overwrite of every image is recoverable.
+#
+# The trade is that replacing an image leaves the old object unreferenced
+# rather than gone. At a fraction of a penny each, that is worth paying.
+
+Resources:
+  MediaWritePolicy:
+    Type: AWS::IAM::RolePolicy
+    Properties:
+      RoleName: apps-ec2-role
+      PolicyName: write-craftr-media
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ReadWriteUploadedImages
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              # Read matters more than it looks. django-storages checks whether
+              # a key already exists before saving, to avoid overwriting, and
+              # that check is a HEAD request needing this permission. Without it
+              # S3 answers 403 rather than 404 for a key that is simply absent,
+              # and the upload fails with a permissions error that names no
+              # permission.
+              - s3:GetObject
+            # The three prefixes the application writes, and nothing wider.
+            # These must match the upload_to values on the model fields
+            # exactly or every upload is denied, so they change together.
+            #
+            # Unlike the-cult-film-club there is no decorative prefix to
+            # exclude here: Craftr's 14 background, workshop and logo images
+            # were moved into the repository and are served by WhiteNoise, so
+            # this bucket holds only genuinely uploaded content.
+            Resource:
+              - arn:aws:s3:::craftr-dominicfrancis/classes/*
+              - arn:aws:s3:::craftr-dominicfrancis/instructors/*
+              - arn:aws:s3:::craftr-dominicfrancis/profiles/*
+
+          - Sid: ListUploadedPrefixes
+            Effect: Allow
+            Action: s3:ListBucket
+            # Bucket ARN, not an object ARN: ListBucket is a bucket-level
+            # action, and pointing it at objects silently grants nothing.
+            Resource: arn:aws:s3:::craftr-dominicfrancis
+            Condition:
+              StringLike:
+                s3:prefix:
+                  - classes/*
+                  - instructors/*
+                  - profiles/*


### PR DESCRIPTION
Phase 2 of #112. Four CloudFormation templates in a new `infra/`.

**Nothing here is applied.** My credentials are read-only. These need an admin profile, and that apply is the point at which this migration starts costing anything.

## Apply order

Each split is a real dependency, not a preference.

| # | Template | Region | Why separate |
|---|---|---|---|
| 1 | `media-bucket.yaml` | `eu-west-2` | Lands alone so the bucket exists before anything references it |
| 2 | `media-certificate.yaml` | **`us-east-1`** | CloudFront accepts certificates from no other region |
| 3 | `media-cdn.yaml` | `eu-west-2` | The bucket policy must name a distribution that does not exist until this stack runs |
| 4 | `media-permissions.yaml` | `eu-west-2` | Modifies `apps-ec2-role`, a shared production role none of the others own |

Step 3 takes the ARN from step 2 as a parameter, because CloudFormation exports cannot cross regions. Step 4 needs `--capabilities CAPABILITY_NAMED_IAM`.

## Three decisions worth reviewing

**The bucket is `craftr-dominicfrancis`, not `craftr`.** The bare name is taken by another AWS account: `HeadBucket` answers 403 for it, while a nonsense control name answers 404. The suffixed form matches `hi-lo-card-game-dominicfrancis` and `older-and-wider-dominicfrancis`.

**No delete permission, at all.** Django has not needed it since 1.3, and the admins clear tickbox blanks the database column rather than removing the object. The trade is that replacing an image leaves the old object unreferenced rather than gone, which costs a fraction of a penny and means a compromised box cannot erase anything. Combined with bucket versioning, even an overwrite of every image is recoverable.

**Write access is scoped to three prefixes**, `classes/`, `instructors/`, `profiles/`, matching the `upload_to` values Phase 3 will set. Unlike `the-cult-film-club` there is no decorative prefix to exclude, because those 14 images moved into the repo in #115.

## Verification

- All four pass `aws cloudformation validate-template` against the real API.
- None of the four stack names is already in use.
- `craftr-dominicfrancis` confirmed available.
- Hosted zone `Z04281911KACWXVUQESMB` confirmed as `dominicfrancis.co.uk`, and no `media.craftr` record exists yet.

One trap is documented in the template: `validate-template` reports `media-permissions.yaml` as needing **no** capabilities, because it does not recognise `AWS::IAM::RolePolicy`. The deploy does need `CAPABILITY_NAMED_IAM` — the applied `tardis-media-permissions` stack has it recorded. The comment says so, to stop anyone dropping the flag later.

## Correction to the issue

#112 says the TARDIS Archives migration is "underway" and that all three sites must move before Cloudinary can close. Both are now out of date, in your favour:

- `tardis-archives#42` is **closed**, with four applied stacks and a live `media.tardisarchives.co.uk`.
- The Cult Film Club has **also** moved: there is a `the-cult-film-club` bucket with `profiles/` and `releases/` prefixes and a live `media.cultfilmclub.dominicfrancis.co.uk`.

So Craftr is the **last of the three**. When this finishes, the Cloudinary account can actually be closed rather than merely reduced.